### PR TITLE
Add timing measurements for analysis

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/phases/BaseTier.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/phases/BaseTier.java
@@ -39,6 +39,8 @@ import jdk.graal.compiler.phases.tiers.HighTierContext;
 import jdk.graal.compiler.phases.tiers.MidTierContext;
 import jdk.graal.compiler.serviceprovider.GraalServices;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class BaseTier<C> extends PhaseSuite<C> {
 
     /**
@@ -65,7 +67,11 @@ public class BaseTier<C> extends PhaseSuite<C> {
                 GraalServices.notifyLowMemoryPoint();
             }
 
-            if (phasePGO.canSkipPhase(phase, graph)) {
+            long beforeCheckTime = System.nanoTime();
+            boolean canSkipPhase = phasePGO.canSkipPhase(phase, graph);
+            checkTime.getAndAdd(System.nanoTime() - beforeCheckTime);
+
+            if (canSkipPhase) {
                 numPhasesSkipped++;
                 continue;
             }
@@ -74,7 +80,13 @@ public class BaseTier<C> extends PhaseSuite<C> {
                 GraphChangeListener listener = new GraphChangeListener(graph);
                 try (Graph.NodeEventScope s = graph.trackNodeEvents(listener)) {
                     try (DebugContext.Scope s2 = graph.getDebug().sandbox("GraphChangeListener", null)) {
+                        long startTime = System.nanoTime();
                         phase.apply(graph, context);
+                        long phaseExecutionTime = System.nanoTime() - startTime;
+                        totalPhaseTimes.computeIfAbsent(phase.getClass(), k -> new AtomicLong()).getAndAdd(phaseExecutionTime);
+                        if (!listener.changed) {
+                            skippablePhaseTimes.computeIfAbsent(phase.getClass(), k -> new AtomicLong()).getAndAdd(phaseExecutionTime);
+                        }
                     } catch (Throwable t) {
                         throw graph.getDebug().handle(t);
                     }

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/phases/PhaseSuite.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/phases/PhaseSuite.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import jdk.graal.compiler.core.common.util.PhasePlan;
@@ -417,6 +419,10 @@ public class PhaseSuite<C> extends BasePhase<C> implements PhasePlan<BasePhase<?
     public static long numPhases = 0;
     public static long numPhasesSkipped = 0;
 
+    public static Map<Class<?>, AtomicLong> totalPhaseTimes = new ConcurrentHashMap<>();
+    public static Map<Class<?>, AtomicLong> skippablePhaseTimes = new ConcurrentHashMap<>();
+    public static AtomicLong checkTime = new AtomicLong();
+
     @Override
     protected void run(StructuredGraph graph, C context) {
         boolean printGraphStateDiff = Options.PrintGraphStateDiff.getValue(graph.getOptions());
@@ -428,7 +434,11 @@ public class PhaseSuite<C> extends BasePhase<C> implements PhasePlan<BasePhase<?
         for (BasePhase<? super C> phase : phases) {
             numPhases++;
             try {
-                if (phasePGO.canSkipPhase(phase, graph)) {
+                long beforeCheckTime = System.nanoTime();
+                boolean canSkipPhase = phasePGO.canSkipPhase(phase, graph);
+                checkTime.getAndAdd(System.nanoTime() - beforeCheckTime);
+
+                if (canSkipPhase) {
                     numPhasesSkipped++;
                     index++;
                     continue;
@@ -438,7 +448,13 @@ public class PhaseSuite<C> extends BasePhase<C> implements PhasePlan<BasePhase<?
                     GraphChangeListener listener = new GraphChangeListener(graph);
                     try (Graph.NodeEventScope s = graph.trackNodeEvents(listener)) {
                         try (DebugContext.Scope s2 = graph.getDebug().sandbox("GraphChangeListener", null)) {
+                            long startTime = System.nanoTime();
                             phase.apply(graph, context);
+                            long phaseExecutionTime = System.nanoTime() - startTime;
+                            totalPhaseTimes.computeIfAbsent(phase.getClass(), k -> new AtomicLong()).getAndAdd(phaseExecutionTime);
+                            if (!listener.changed) {
+                                skippablePhaseTimes.computeIfAbsent(phase.getClass(), k -> new AtomicLong()).getAndAdd(phaseExecutionTime);
+                            }
                         } catch (Throwable t) {
                             throw graph.getDebug().handle(t);
                         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -27,6 +27,7 @@ package com.oracle.svm.hosted;
 import static com.oracle.graal.pointsto.api.PointstoOptions.UseExperimentalReachabilityAnalysis;
 import static com.oracle.svm.hosted.NativeImageOptions.DiagnosticsDir;
 import static com.oracle.svm.hosted.NativeImageOptions.DiagnosticsMode;
+import static jdk.graal.compiler.core.common.util.ReversedList.reversed;
 import static jdk.graal.compiler.hotspot.JVMCIVersionCheck.OPEN_LABSJDK_RELEASE_URL_PATTERN;
 import static jdk.graal.compiler.replacements.StandardGraphBuilderPlugins.registerInvocationPlugins;
 
@@ -50,6 +51,8 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
@@ -784,6 +787,20 @@ public class NativeImageGenerator {
 
         System.out.printf("Total skippable fingerprints recorded: %d%n", phasePGO.numberOfSkippablePhases());
         System.out.printf("Total phases ran: %d, total phases skipped: %d%n", PhaseSuite.numPhases, PhaseSuite.numPhasesSkipped);
+
+        System.out.printf("%nTotal phase time cumulative: %.3f sec%n", (double) PhaseSuite.totalPhaseTimes.values().stream().map(AtomicLong::get).reduce(0L, Long::sum) / 1e9);
+        PhaseSuite.totalPhaseTimes.entrySet().stream()
+                .map((e) -> Map.entry(e.getKey().getSimpleName(), e.getValue().get()))
+                .sorted(Map.Entry.comparingByValue(Collections.reverseOrder()))
+                .forEach((e) -> System.out.printf("Phase %-35s total time: %.3f sec%n", e.getKey(), (double) e.getValue() / 1e9));
+
+        System.out.printf("%nTotal skippable phase time cumulative: %.3f sec%n", (double) PhaseSuite.skippablePhaseTimes.values().stream().map(AtomicLong::get).reduce(0L, Long::sum) / 1e9);
+        PhaseSuite.skippablePhaseTimes.entrySet().stream()
+            .map((e) -> Map.entry(e.getKey().getSimpleName(), e.getValue().get()))
+            .sorted(Map.Entry.comparingByValue(Collections.reverseOrder()))
+            .forEach((e) -> System.out.printf("Phase %-35s total time: %.3f sec%n", e.getKey(), (double) e.getValue() / 1e9));
+
+        System.out.printf("%nTotal time to pass skippable check: %.3f sec%n", (double) PhaseSuite.checkTime.get() / 1e9);
     }
 
     /*


### PR DESCRIPTION
This branch simply instruments the phase skipping logic with timing measurements which we use during evaluation in the thesis. It is separated from the main branch because the time measurements incur a performance overhead which should not be present in the main evaluation.